### PR TITLE
Install which

### DIFF
--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -9,8 +9,9 @@ RUN yum install -y \
                    git \
                    make \
                    patch \
-                   tar \ 
-                   wget
+                   tar \
+                   wget \
+                   which
 
 RUN wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh --no-verbose && \
     bash Miniconda-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \


### PR DESCRIPTION
I found out that `which`, needed by some `configure` scripts, is not installed by default on this centos image.