### PR TITLE
Made use of the build/skip section for identification of distributions to build.

### DIFF
--- a/obvci/conda_tools/build_directory.py
+++ b/obvci/conda_tools/build_directory.py
@@ -56,22 +56,13 @@ def fetch_metas(directory):
     The recipes will be sorted by the order of their directory name.
 
     """
-    if os.name == 'nt':
-        build_script = 'bld.bat'
-    else:
-        build_script = 'build.sh'
-
     packages = []
     for package_name in sorted(os.listdir(directory)):
         package_dir = os.path.join(directory, package_name)
         meta_yaml = os.path.join(package_dir, 'meta.yaml')
 
         if os.path.isdir(package_dir) and os.path.exists(meta_yaml):
-            # Only include packages which have an appropriate build script.
-            # TODO: This could become more flexible by allowing a exclude.lst
-            # file in the recipe?
-            if os.path.exists(os.path.join(package_dir, build_script)):
-                packages.append(MetaData(package_dir))
+            packages.append(MetaData(package_dir))
 
     return packages
 
@@ -145,7 +136,8 @@ class BakedDistribution(object):
             # Trigger the recipe to be re-read. This means that any version
             # specific qualifiers will be set appropriately.
             dist.parse_again()
-            result.append(dist)
+            if not dist.skip():
+                result.append(dist)
         return result
 
 

--- a/obvci/tests/unit/conda/test_BakedDistribution.py
+++ b/obvci/tests/unit/conda/test_BakedDistribution.py
@@ -69,7 +69,6 @@ class Test_baked_version(unittest.TestCase):
 
         meta = MetaData(self.recipe_dir)
 
-        index = {'python-2.7-0.tar.bz2': {'name': 'python', 'version': '2.7', 'build_number': 0}}
         self.index.add_pkg('python', '2.7.2')
         self.index.add_pkg('python', '2.6.2')
         self.index.add_pkg('python', '3.5.0')
@@ -78,6 +77,33 @@ class Test_baked_version(unittest.TestCase):
         self.assertEqual(len(r), 2)
         self.assertEqual(r[0].build_id(), 'np18py27_0')
         self.assertEqual(r[1].build_id(), 'np18py35_0')
+
+    def test_py_xx_version(self):
+        recipe = """
+            package:
+                name: recipe_which_depends_on_py_version
+                version: 2
+            build:
+                skip: True  # [py3k]
+            requirements:
+                build:
+                    - python
+                run:
+                    - python
+            """
+        with open(os.path.join(self.recipe_dir, 'meta.yaml'), 'w') as fh:
+            fh.write(recipe)
+        conda_build.config.config.CONDA_PY = 35
+
+        meta = MetaData(self.recipe_dir)
+
+        self.index.add_pkg('python', '2.7.2')
+        self.index.add_pkg('python', '2.6.2')
+        self.index.add_pkg('python', '3.5.0')
+        r = BakedDistribution.compute_matrix(meta, self.index)
+        self.assertEqual(len(r), 2)
+        self.assertEqual(r[0].build_id(), 'py27_0')
+        self.assertEqual(r[1].build_id(), 'py26_0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ping @ocefpaf.

obvious-ci now no longer determines whether a distribution can be built based on whether it has a ``bld.bat`` or a ``build.sh``. Instead, the build/skip metadata is used, as per https://github.com/conda/conda-build/pull/566.

This has a number of advantages, including the fact that we can now define recipes which need neither a build.sh nor a bld.bat (and we can therefore define the build command in the metadata itself).

This does break some existing installations though. See https://github.com/SciTools/conda-recipes-scitools/pull/119 for one solution.