### PR TITLE
Gather multi-line specifications into a single specification

### DIFF
--- a/obvci/conda_tools/from_conda_manifest_core_vn_matrix.py
+++ b/obvci/conda_tools/from_conda_manifest_core_vn_matrix.py
@@ -1,6 +1,7 @@
 # TODO: Pull this back together with conda_manifest.
 import os
 from contextlib import contextmanager
+from collections import defaultdict
 
 import conda.resolve
 from conda.resolve import MatchSpec
@@ -123,9 +124,20 @@ def special_case_version_matrix(meta, index):
     requirement_specs = {MatchSpec(spec).name: MatchSpec(spec)
                          for spec in requirements}
     run_requirements = meta.get_value('requirements/run', [])
-    run_requirement_specs = {MatchSpec(spec).name: MatchSpec(spec)
-                             for spec in run_requirements}
+    run_requirement_specs = defaultdict(list)
+    # Generate a list of requirements for each spec name to ensure that
+    # multi-line specs are handled.
+    for spec in run_requirements:
+        run_requirement_specs[MatchSpec(spec).name].append(spec)
 
+    # Combine multi-line specs into a single line by assuming the requirements
+    # should be and-ed.
+    for spec_name, spec_list in run_requirement_specs.iteritems():
+        run_requirement_specs[spec_name] = ','.join(spec_list)
+
+    # Turn these into MatchSpecs.
+    run_requirement_specs = {name: MatchSpec(spec)
+                             for name, spec in run_requirement_specs.iteritems()}
 
     # Thanks to https://github.com/conda/conda-build/pull/493 we no longer need to
     # compute the complex matrix for numpy versions unless a specific version has


### PR DESCRIPTION
This is a little hack-y but accommodates a few of the current oddities of building with conda, listed below:

+ The numpy version is only baked in to the build id/package requirements if `numpy x.x` appears, in a line by itself, in `requirements/run`. The numpy version is only set properly during build if `numpy x.x` appears in a line by itself in the build section also. As a result, the only way to express the need to pin numpy and restrictions on numpy version is like this:

```
requirements:
  build:
    - numpy x.x
    - numpy >=1.9
```

+ Similarly, python is included in the build string and its version pinned by `CONDA_PY` only if python is listed by itself, so specifying pinning and version restrictions requires two lines (note that conda-build effectively ignores the python restriction if `CONDA_PY` is inconsistent with it):

```
requirements:
  build:
    - python
    - python >=2.6|>=3.4
```

Both of these cause problems for the current Obvious-CI because it builds up the list of requirements as a dictionary, so the last requirement is the only one kept.

This PR joins requirements spread over more than one line by assuming they are intended to be and-ed together.
