### PR TITLE
Minor image improvements

### DIFF
--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -3,8 +3,10 @@ FROM centos:6
 MAINTAINER Phil Elson <pelson.pub@gmail.com>
 
 
+# Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
+# Install requirements for 64-bit only.
 RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
     yum update -y && \
     yum install -y \
@@ -21,19 +23,23 @@ RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
                    libX11-devel && \
     yum clean all
 
+# Download and install tini for zombie reaping.
 RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
     openssl md5 tini | grep 596b898785d2f169ec969445087c14d6 && \
     chmod +x tini && \
     mv tini /usr/local/bin
 
+# Install the latest Miniconda with Python 3 and update everything.
 RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
     conda update --all --yes && conda clean -tipsy
 
+# Add conda and friends to the path.
 ENV PATH /opt/conda/bin:$PATH
 
+# Install Obvious-CI.
 RUN conda install --yes -c pelson/channel/development obvious-ci && \
     obvci_install_conda_build_tools.py
 
@@ -41,5 +47,7 @@ RUN conda install --yes -c pelson/channel/development obvious-ci && \
 # libtool texinfo
 # RUN yum install -y expat-devel
 
+# Ensure that all containers start with tini and the user selected process.
+# Provide a default command (`bash`), which will start if the user doesn't specify one.
 ENTRYPOINT [ "/usr/local/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -6,9 +6,8 @@ MAINTAINER Phil Elson <pelson.pub@gmail.com>
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8
 
-# Install requirements for 64-bit only.
-RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
-    yum update -y && \
+# Install basic requirements.
+RUN yum update -y && \
     yum install -y \
                    bzip2 \
                    gcc-c++ \

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -21,7 +21,12 @@ RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
                    libX11-devel && \
     yum clean all
 
-RUN curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
+    openssl md5 tini | grep 596b898785d2f169ec969445087c14d6 && \
+    chmod +x tini && \
+    mv tini /usr/local/bin
+
+RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
@@ -36,3 +41,6 @@ RUN export PATH=/opt/conda/bin:$PATH && \
 # RUN yum install -y expat-devel
 
 ENV PATH /opt/conda/bin:$PATH
+
+ENTRYPOINT [ "/usr/local/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -2,6 +2,9 @@ FROM centos:6
 
 MAINTAINER Phil Elson <pelson.pub@gmail.com>
 
+
+ENV LANG en_US.UTF-8
+
 RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
     yum update -y && \
     yum install -y \
@@ -34,5 +37,3 @@ RUN export PATH=/opt/conda/bin:$PATH && \
 # RUN yum install -y expat-devel
 
 ENV PATH /opt/conda/bin:$PATH
-
-ENV LANG en_US.UTF-8

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
                    make \
                    patch \
                    tar \
-                   wget \
                    which \
                    libXext \
                    libXrender \
@@ -22,7 +21,7 @@ RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
                    libX11-devel && \
     yum clean all
 
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
+RUN curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -2,7 +2,8 @@ FROM centos:6
 
 MAINTAINER Phil Elson <pelson.pub@gmail.com>
 
-RUN yum install -y \
+RUN yum update -y && \
+    yum install -y \
                    bzip2 \
                    gcc-c++ \
                    git \
@@ -14,7 +15,8 @@ RUN yum install -y \
                    libXext \
                    libXrender \
                    libSM \
-                   libX11-devel
+                   libX11-devel && \
+    yum clean all
 
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && rm Miniconda*.sh && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set show_channel_urls True && \
-    conda update --all --yes && conda clean -t -p
+    conda update --all --yes && conda clean -tipsy
 
 RUN export PATH=/opt/conda/bin:$PATH && \
     conda install --yes -c pelson/channel/development obvious-ci && \

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -32,15 +32,14 @@ RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x8
     conda config --set show_channel_urls True && \
     conda update --all --yes && conda clean -tipsy
 
-RUN export PATH=/opt/conda/bin:$PATH && \
-    conda install --yes -c pelson/channel/development obvious-ci && \
+ENV PATH /opt/conda/bin:$PATH
+
+RUN conda install --yes -c pelson/channel/development obvious-ci && \
     obvci_install_conda_build_tools.py
 
 # udunits2.
 # libtool texinfo
 # RUN yum install -y expat-devel
-
-ENV PATH /opt/conda/bin:$PATH
 
 ENTRYPOINT [ "/usr/local/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -2,7 +2,8 @@ FROM centos:6
 
 MAINTAINER Phil Elson <pelson.pub@gmail.com>
 
-RUN yum update -y && \
+RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
+    yum update -y && \
     yum install -y \
                    bzip2 \
                    gcc-c++ \


### PR DESCRIPTION
Just as FYI, it is recommended to run `yum update` first. However, `yum` leaves some state that can mess up future containers due to how COW file systems work. So, `yum clean all` needs to be run too. In particular, they both need to be in the same commit. Here is a [simple example]( https://github.com/docker-library/docs/tree/master/centos#minor-tags ) from the base CentOS image docs. This will also cut down on layer size, which probably isn't too much of an issue for us now, but it is good to be aware. Keep in mind that `yum update` may be needed at startup, as we have cleaned out all of the information from `yum`.

Additionally, I added a line to exclude 32-bit binaries from being installed just as a good measure.

Added a few more things to clean from `conda`.

Also, moved the UTF-8 setting to the beginning. I have in the past (not recently) ran into bugs with `conda` due to the fact that it had no known encoding set. This will bypass those issues.

Switched to `curl`, which is included by default with the system.

Install [`tini`]( https://github.com/krallin/tini ) (a super small init process) to reap zombie processes.