### PR TITLE
Use devtoolset-2 for C++11 and other support

### DIFF
--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -23,6 +23,19 @@ RUN yum update -y && \
                    mesa-libGL-devel && \
     yum clean all
 
+# Install devtoolset 2.
+RUN yum update -y && \
+    yum install -y \
+                   centos-release-scl \
+                   yum-utils && \
+    yum-config-manager --add-repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
+    yum update -y && \
+    yum install -y \
+                   devtoolset-2-binutils \
+                   devtoolset-2-gcc \
+                   devtoolset-2-gcc-c++ && \
+    yum clean all
+
 # Download and install tini for zombie reaping.
 RUN curl -s -L -O https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
     openssl md5 tini | grep 596b898785d2f169ec969445087c14d6 && \

--- a/obvious-ci.docker/linux64_obvci/entrypoint_source
+++ b/obvious-ci.docker/linux64_obvci/entrypoint_source
@@ -1,2 +1,11 @@
+# Enable the compiler toolset.
+#
+# Must do this before activating conda or
+# the system Python interpreter is not used.
+# This is a problem for many reasons. One being
+# that the Python scripts used to activate the
+# toolset are not Python 3 compatible.
+. scl_source enable devtoolset-2
+
 # Activate the `root` conda environment.
 . /opt/conda/bin/activate root


### PR DESCRIPTION
I have decided to propose this as a PR so that we have a clear idea of the change I am suggesting here.

Already this works and builds correctly on my machine and has been tested with staged recipes using this [commit]( https://github.com/conda-forge/staged-recipes/tree/a928665c51d74aec41ac4eec085b2d8222a721a6 ) and found to be working correctly.

Instead of using the `ENV` Docker command, we have moved towards proper activation of the `conda` environment. This needed primarily as enabling a `devtoolset` relies on using the system python interpreter. There are probably other reasons this is a good idea. The main one is that the activation process requires Python 2 only code to run. We currently use Python 3 for the miniconda install. So, we must activate the devtoolset first and then activate conda. This has been done by adding the entrypoint script below.

The entrypoint script simply activates the devtoolset, then conda, and then runs any commands provided by the user. The behavior as seen by the user is unchanged with the exception of the compiler being switched. We can keep this entrypoint script as a separate file or we can move the contents of the file directly into the docker image using `echo` calls within a single `RUN` command.

Everything else that happens here is quite straightforward. Please ask questions or make comments as needed. Will cross reference this in the compiler issue ( https://github.com/conda-forge/conda-forge.github.io/issues/29 ).