### PR TITLE
docker: Activate conda `root` with an entrypoint script

### DIFF
--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -35,18 +35,18 @@ RUN curl -s -L -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x8
     conda config --set show_channel_urls True && \
     conda update --all --yes && conda clean -tipsy
 
-# Add conda and friends to the path.
-ENV PATH /opt/conda/bin:$PATH
-
 # Install Obvious-CI.
-RUN conda install --yes -c pelson/channel/development obvious-ci && \
+RUN export PATH="/opt/conda/bin:${PATH}" && \
+    conda install --yes -c pelson/channel/development obvious-ci && \
     obvci_install_conda_build_tools.py
 
 # udunits2.
 # libtool texinfo
 # RUN yum install -y expat-devel
 
+COPY entrypoint /opt/docker/bin/entrypoint
+
 # Ensure that all containers start with tini and the user selected process.
 # Provide a default command (`bash`), which will start if the user doesn't specify one.
-ENTRYPOINT [ "/usr/local/bin/tini", "--" ]
+ENTRYPOINT [ "/usr/local/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
 CMD [ "/bin/bash" ]

--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -44,6 +44,7 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
 # libtool texinfo
 # RUN yum install -y expat-devel
 
+COPY entrypoint_source /opt/docker/bin/entrypoint_source
 COPY entrypoint /opt/docker/bin/entrypoint
 
 # Ensure that all containers start with tini and the user selected process.

--- a/obvious-ci.docker/linux64_obvci/entrypoint
+++ b/obvious-ci.docker/linux64_obvci/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Activate the `root` conda environment.
-. /opt/conda/bin/activate root
+# Source everything that needs to be.
+. /opt/docker/bin/entrypoint_source
 
 # Run whatever the user wants.
 exec "$@"

--- a/obvious-ci.docker/linux64_obvci/entrypoint
+++ b/obvious-ci.docker/linux64_obvci/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Activate the `root` conda environment.
+. /opt/conda/bin/activate root
+
+# Run whatever the user wants.
+exec "$@"

--- a/obvious-ci.docker/linux64_obvci/entrypoint_source
+++ b/obvious-ci.docker/linux64_obvci/entrypoint_source
@@ -1,0 +1,2 @@
+# Activate the `root` conda environment.
+. /opt/conda/bin/activate root


### PR DESCRIPTION
Instead of adding `conda` to the `$PATH`. This adds an entrypoint script, which activates the environment as part of the container startup process. It has been tested on this [commit]( https://github.com/conda-forge/staged-recipes/tree/a928665c51d74aec41ac4eec085b2d8222a721a6 ) and run successfully.