### PR TITLE
Add Mesa OpenGL support to the container

### DIFF
--- a/obvious-ci.docker/linux64_obvci/Dockerfile
+++ b/obvious-ci.docker/linux64_obvci/Dockerfile
@@ -19,7 +19,8 @@ RUN yum update -y && \
                    libXext \
                    libXrender \
                    libSM \
-                   libX11-devel && \
+                   libX11-devel \
+                   mesa-libGL-devel && \
     yum clean all
 
 # Download and install tini for zombie reaping.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pyopengl-feedstock/issues/1
Related: https://github.com/conda-forge/staged-recipes/pull/327/files#r59378775

This installs Mesa OpenGL in the container so that we can test things that require OpenGL support. Mac and Windows come with this out of the box. With Linux, this is one install away. Here we just add it to the container.