### PR TITLE
Fix AppVeyor downloading a corrupted Miniconda

### DIFF
--- a/bootstrap-obvious-ci-and-miniconda.py
+++ b/bootstrap-obvious-ci-and-miniconda.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from urllib import urlretrieve
 
-MINICONDA_URL_TEMPLATE = ('http://repo.continuum.io/miniconda/Miniconda{major_py_version}-'
+MINICONDA_URL_TEMPLATE = ('https://repo.continuum.io/miniconda/Miniconda{major_py_version}-'
                           '{miniconda_version}-{OS}-{arch}.{ext}')
 
 


### PR DESCRIPTION
Should fix https://ci.appveyor.com/project/conda-forge/lapack-feedstock/build/1.0.24/job/cm6vb5fknxp5clo0 and all the others https://ci.appveyor.com/project/conda-forge/cython-feedstock/build/job/8d6tmrwj6twtwqal
