### PR TITLE
Include the license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include versioneer.py
 include obvci/_version.py


### PR DESCRIPTION
Include the license file in `MANIFEST.in` so it can be properly packaged.