### PR TITLE
Fix for python 2 miniconda url 

### DIFF
--- a/bootstrap-obvious-ci-and-miniconda.py
+++ b/bootstrap-obvious-ci-and-miniconda.py
@@ -46,7 +46,7 @@ def miniconda_url(target_system, target_arch, major_py_version, miniconda_versio
 
     if major_py_version not in ['2', '3']:
         raise ValueError('Unexpected major Python version {!r}.'.format(major_py_version))
-    template_values['major_py_version'] = major_py_version if major_py_version == '3' else ''
+    template_values['major_py_version'] = major_py_version if major_py_version == '3' else '2'
     
     return MINICONDA_URL_TEMPLATE.format(**template_values)
 


### PR DESCRIPTION
Fixes an issue with the url template for getting the latest python2 version as per naming convention change at https://repo.continuum.io/miniconda/.

Tested on a travis build for a project of mine that before kept failing on python 2 only.